### PR TITLE
Factor out recoding related docs

### DIFF
--- a/hosting.md
+++ b/hosting.md
@@ -2,73 +2,21 @@
 
 This is a detailed guide for how to prepare and host Nixpkgs Architecture Team meetings.
 
-## One-time setup
-
-These steps are only necessary once.
-
-### Getting a Google account
-
-In order to have access to the YouTube channel, you need a Google account.
-If you have one already you can use that one, but you're free to create a new one as well.
-
-#### Creating a new Google account
-
-- Go to [YouTube](https://www.youtube.com/)
-- Click on the "Sign In" button at the very top right
-- Click on "Create account"
-- Follow the steps to your liking
-
-#### Copying the E-Mail address of your Google account
-
-- Go to the [Google Account page](https://myaccount.google.com/)
-- Click on the round icon at the top right of the page
-- Copy the E-Mail it displays to the clipboard
-
-### Get access to the YouTube channel
-
-- Send the E-Mail address of your Google account to [@infinisil:matrix.org](https://matrix.to/#/@infinisil:matrix.org)
-- [@infinisil:matrix.org](https://matrix.to/#/@infinisil:matrix.org) will do the following steps for you:
-  - Go to [YouTube Studio](https://studio.youtube.com/)
-  - Make sure you're on the Nixpkgs Architecture Team account
-  - Click on "Settings" on the bottom left, a panel should open
-  - Click on the "Permissions" tab
-  - Click on "Invite"
-  - Enter the E-Mail address of your Google account
-  - Select "Editor" in the "Access" field
-
 ## Before every the meeting
-
-### Preparing the live stream
-
-- Go to [YouTube Studio > Go Live > Manage](https://studio.youtube.com/)
-- Click on "SCHEDULE STREAM"
-- Click on "REUSE SETTINGS"
-- Update the meeting number and the date in the title
-- Click "NEXT" to get to the Customization tab
-- Click "NEXT" to get to the Visibility tab
-- If the meeting doesn't happen in your timezone (see the [NixOS Calendar](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com&ctz=Europe/Zurich)), run the following command, replacing `<date>`, `<time>` and `<timezone>` with the details from the meeting, to figure out the time in your local timezone
-
-  ```
-  date --date='<date> <time> <timezone>' +'%Y-%m-%d %r'
-  ```
-
-- Under "Schedule", enter the date and time returned from the above command
-- Click "DONE"
 
 ### Announcing the meeting
 
 - Write a message on the [#nixpkgs-architecture:nixos.org](https://matrix.to/#/#nixpkgs-architecture:nixos.org) Matrix channel with the following content:
 
   ```
-  @room: The next meeting will take place soon - [meeting link](https://meet.jit.si/nixpkgs-architecture) - [live stream](https://www.youtube.com/@nixpkgs-architecture) - [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ)
+  @room: The next meeting will take place soon - [meeting link](https://meet.jit.si/nixpkgs-architecture) - [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ)
   ```
 
 ### Preparing the meeting notes
 
 - Go to the [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ?edit)
-- Fill out the "Recording" field with the URL to the live-stream. To get the URL, click on the Arrow button on the top right in the live-stream tab
 - Fill out the "Matrix announcement" field with the URL to the Matrix message
-- Fill out the "Who records" and "Who leads the meeting" fields with your nickname
+- Fill out the "Who leads the meeting" fields with your nickname
 - Fill out the "Who takes meeting notes" field with the person appointed with taking meeting notes
 
 ## The meeting
@@ -77,19 +25,10 @@ If you have one already you can use that one, but you're free to create a new on
 - Wait a couple minutes
   - Make sure the person taking meeting notes is present
   - Make sure the "Attending" field of the meeting notes includes at least all the present NAT members
-- Start the live-stream
-  - Click on the "..." button
-  - Click on the "Start live stream" entry
-  - Copy the "Stream key" from the live-stream tab and paste it into the Jitsi tab
-  - Click the "Start live stream" button
-  - Wait until you get confirmation that the stream was started, this takes about 10 seconds
 - Have the meeting
   - Keep the time in mind
   - Keep the discussion on-topic
 - When the meeting time is up or there's nothing else to discuss, end the meeting and mention that people are free to continue the discussion here
-- Stop the live-stream
-  - Click on the "..." button
-  - Click on the "Stop live stream" entry
 
 ## Afterwards
 

--- a/live-streaming.md
+++ b/live-streaming.md
@@ -1,4 +1,10 @@
-## One-time setup
+# YouTube streaming setup
+
+The Nixpkgs Architecture Team has a [YouTube](https://www.youtube.com/@nixpkgs-architecture) channel that can be used to stream presentations, and has been used for past meetings.
+
+This document describes how to set it up.
+
+## One-time
 
 These steps are only necessary once.
 
@@ -32,7 +38,7 @@ If you have one already you can use that one, but you're free to create a new on
   - Enter the E-Mail address of your Google account
   - Select "Editor" in the "Access" field
 
-## Before every the meeting
+## Before every stream
 
 ### Preparing the live stream
 
@@ -42,7 +48,8 @@ If you have one already you can use that one, but you're free to create a new on
 - Update the meeting number and the date in the title
 - Click "NEXT" to get to the Customization tab
 - Click "NEXT" to get to the Visibility tab
-- If the meeting doesn't happen in your timezone (see the [NixOS Calendar](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com&ctz=Europe/Zurich)), run the following command, replacing `<date>`, `<time>` and `<timezone>` with the details from the meeting, to figure out the time in your local timezone
+- YouTube always uses your local timezone, so if the meeting happens in a different one you need to convert the timezone.
+  To do so you can run the following command, replacing `<date>`, `<time>` and `<timezone>` with the details of the stream time:
 
   ```
   date --date='<date> <time> <timezone>' +'%Y-%m-%d %r'
@@ -51,35 +58,13 @@ If you have one already you can use that one, but you're free to create a new on
 - Under "Schedule", enter the date and time returned from the above command
 - Click "DONE"
 
-### Announcing the meeting
+### Starting the stream
+- Click on the "..." button
+- Click on the "Start live stream" entry
+- Copy the "Stream key" from the live-stream tab and paste it into the Jitsi tab
+- Click the "Start live stream" button
+- Wait until you get confirmation that the stream was started, this takes about 10 seconds
 
-- Write a message on the [#nixpkgs-architecture:nixos.org](https://matrix.to/#/#nixpkgs-architecture:nixos.org) Matrix channel with the following content:
-- @room: The next meeting will take place soon - [meeting link](https://meet.jit.si/nixpkgs-architecture) - [live stream](https://www.youtube.com/@nixpkgs-architecture) - [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ)
-
-### Preparing the meeting notes
-
-- Go to the [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ?edit)
-- Fill out the "Recording" field with the URL to the live-stream. To get the URL, click on the Arrow button on the top right in the live-stream tab
-- Fill out the "Matrix announcement" field with the URL to the Matrix message
-- Fill out the "Who records" and "Who leads the meeting" fields with your nickname
-- Fill out the "Who takes meeting notes" field with the person appointed with taking meeting notes
-
-## The meeting
-
-- Join the [Jitsi meeting](https://meet.jit.si/nixpkgs-architecture)
-- Wait a couple minutes
-  - Make sure the person taking meeting notes is present
-  - Make sure the "Attending" field of the meeting notes includes at least all the present NAT members
-- Start the live-stream
-  - Click on the "..." button
-  - Click on the "Start live stream" entry
-  - Copy the "Stream key" from the live-stream tab and paste it into the Jitsi tab
-  - Click the "Start live stream" button
-  - Wait until you get confirmation that the stream was started, this takes about 10 seconds
-- Have the meeting
-  - Keep the time in mind
-  - Keep the discussion on-topic
-- When the meeting time is up or there's nothing else to discuss, end the meeting and mention that people are free to continue the discussion here
-- Stop the live-stream
-  - Click on the "..." button
-  - Click on the "Stop live stream" entry
+### Stopping the stream
+- Click on the "..." button
+- Click on the "Stop live stream" entry

--- a/live-streaming.md
+++ b/live-streaming.md
@@ -1,0 +1,85 @@
+## One-time setup
+
+These steps are only necessary once.
+
+### Getting a Google account
+
+In order to have access to the YouTube channel, you need a Google account.
+If you have one already you can use that one, but you're free to create a new one as well.
+
+#### Creating a new Google account
+
+- Go to [YouTube](https://www.youtube.com/)
+- Click on the "Sign In" button at the very top right
+- Click on "Create account"
+- Follow the steps to your liking
+
+#### Copying the E-Mail address of your Google account
+
+- Go to the [Google Account page](https://myaccount.google.com/)
+- Click on the round icon at the top right of the page
+- Copy the E-Mail it displays to the clipboard
+
+### Get access to the YouTube channel
+
+- Send the E-Mail address of your Google account to [@infinisil:matrix.org](https://matrix.to/#/@infinisil:matrix.org)
+- [@infinisil:matrix.org](https://matrix.to/#/@infinisil:matrix.org) will do the following steps for you:
+  - Go to [YouTube Studio](https://studio.youtube.com/)
+  - Make sure you're on the Nixpkgs Architecture Team account
+  - Click on "Settings" on the bottom left, a panel should open
+  - Click on the "Permissions" tab
+  - Click on "Invite"
+  - Enter the E-Mail address of your Google account
+  - Select "Editor" in the "Access" field
+
+## Before every the meeting
+
+### Preparing the live stream
+
+- Go to [YouTube Studio > Go Live > Manage](https://studio.youtube.com/)
+- Click on "SCHEDULE STREAM"
+- Click on "REUSE SETTINGS"
+- Update the meeting number and the date in the title
+- Click "NEXT" to get to the Customization tab
+- Click "NEXT" to get to the Visibility tab
+- If the meeting doesn't happen in your timezone (see the [NixOS Calendar](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com&ctz=Europe/Zurich)), run the following command, replacing `<date>`, `<time>` and `<timezone>` with the details from the meeting, to figure out the time in your local timezone
+
+  ```
+  date --date='<date> <time> <timezone>' +'%Y-%m-%d %r'
+  ```
+
+- Under "Schedule", enter the date and time returned from the above command
+- Click "DONE"
+
+### Announcing the meeting
+
+- Write a message on the [#nixpkgs-architecture:nixos.org](https://matrix.to/#/#nixpkgs-architecture:nixos.org) Matrix channel with the following content:
+- @room: The next meeting will take place soon - [meeting link](https://meet.jit.si/nixpkgs-architecture) - [live stream](https://www.youtube.com/@nixpkgs-architecture) - [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ)
+
+### Preparing the meeting notes
+
+- Go to the [meeting notes](https://pad.lassul.us/uIi7xeSJTW6LJUEHulZgVQ?edit)
+- Fill out the "Recording" field with the URL to the live-stream. To get the URL, click on the Arrow button on the top right in the live-stream tab
+- Fill out the "Matrix announcement" field with the URL to the Matrix message
+- Fill out the "Who records" and "Who leads the meeting" fields with your nickname
+- Fill out the "Who takes meeting notes" field with the person appointed with taking meeting notes
+
+## The meeting
+
+- Join the [Jitsi meeting](https://meet.jit.si/nixpkgs-architecture)
+- Wait a couple minutes
+  - Make sure the person taking meeting notes is present
+  - Make sure the "Attending" field of the meeting notes includes at least all the present NAT members
+- Start the live-stream
+  - Click on the "..." button
+  - Click on the "Start live stream" entry
+  - Copy the "Stream key" from the live-stream tab and paste it into the Jitsi tab
+  - Click the "Start live stream" button
+  - Wait until you get confirmation that the stream was started, this takes about 10 seconds
+- Have the meeting
+  - Keep the time in mind
+  - Keep the discussion on-topic
+- When the meeting time is up or there's nothing else to discuss, end the meeting and mention that people are free to continue the discussion here
+- Stop the live-stream
+  - Click on the "..." button
+  - Click on the "Stop live stream" entry

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ The Nixpkgs Architecture Team is there to solve architectural nixpkgs issues tha
 
 This section describes the process of going from an issue to a solution. While described here as one, this shouldn't be a linear process. Instead this should be done in a feedback-oriented way.
 
-Every issue considered considered by this team is tracked by [this project board](https://github.com/orgs/nixpkgs-architecture/projects/2).
+Every issue considered by this team is tracked by [this project board](https://github.com/orgs/nixpkgs-architecture/projects/2).
 
 The recommended way to track progress for a specific issue is to create a separate project board and fill it with nixpkgs issues.
 
@@ -136,6 +136,6 @@ Team communication happens in mainly these forms:
 
 Meetings are held on [Jitsi](https://meet.jit.si/nixpkgs-architecture) and are fully public. Meetings are tracked as a calendar event in the public [NixOS Google Calendar](https://calendar.google.com/calendar/embed?src=b9o52fobqjak8oq8lfkhg3t0qg%40group.calendar.google.com&ctz=Europe%2FZurich). If you're interested in participating (whether you're a member of the team or not), ask for an invite with your Email in [#nixpkgs-architecture:nixos.org](https://matrix.to/#/#nixpkgs-architecture:nixos.org), so you get automatic updates when something changes about the event. Anybody that's already invited to the meeting is free and encouraged to invite anybody else.
 
-Every meeting is live-streamed/uploaded to the [Nixpkgs Architecture Team YouTube channel](https://www.youtube.com/@nixpkgs-architecture) for later viewing. Meeting notes are taken on https://pad.lassul.us/ and later committed to https://github.com/nixpkgs-architecture/meetings.
+Meeting notes are taken on https://pad.lassul.us/ and later committed to https://github.com/nixpkgs-architecture/meetings.
 
 A guide for how to host these meetings can be found [here](./hosting.md)


### PR DESCRIPTION
The team decided to stop record the meetings as this relaxes the atmosphere and creates a more comfortable environment for people to speak freely.

We still have the meeting notes to record what happened.
